### PR TITLE
Removing "@Override" beacause it's no longer supported by ReactNative.

### DIFF
--- a/android/src/main/java/com/rnim/rn/audio/ReactNativeAudioPackage.java
+++ b/android/src/main/java/com/rnim/rn/audio/ReactNativeAudioPackage.java
@@ -33,7 +33,6 @@ public class ReactNativeAudioPackage implements ReactPackage {
      * listed here. Also listing a native module here doesn't imply that the JS implementation of it
      * will be automatically included in the JS bundle.
      */
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
With newer versions the modules no longer compiles for android because of the extra "@override"